### PR TITLE
Suppressions in compiler generated code driven by state machine attributes

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1561,36 +1561,36 @@ class Test
 
 #### `IL2103`: Trim analysis: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor
 
-The value passed to the `propertyAccessor` parameter of `Expression.Property(expression, propertyAccessor)` was not recognized as a property accessor method. Trimmer can't guarantee the presence of the property.
+- The value passed to the `propertyAccessor` parameter of `Expression.Property(expression, propertyAccessor)` was not recognized as a property accessor method. Trimmer can't guarantee the presence of the property.
 
-```C#
-void TestMethod(MethodInfo methodInfo)
-{
-  // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.
-  Expression.Property(null, methodInfo);
-}
-```
+  ```C#
+  void TestMethod(MethodInfo methodInfo)
+  {
+    // IL2103: Value passed to the 'propertyAccessor' parameter of method 'System.Linq.Expressions.Expression.Property(Expression, MethodInfo)' cannot be statically determined as a property accessor.
+    Expression.Property(null, methodInfo);
+  }
+  ```
 
 #### `IL2104`: Assembly 'assembly' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries
 
-The assembly 'assembly' produced trim analysis warnings in the context of the app. This means the assembly has not been fully annotated for trimming. Consider contacting the library author to request they add trim annotations to the library. To see detailed warnings for this assembly, turn off grouped warnings by passing either `--singlewarn-` to show detailed warnings for all assemblies, or `--singlewarn- "assembly"` to show detailed warnings for that assembly. https://aka.ms/dotnet-illink/libraries has more information on annotating libraries for trimming.
+- The assembly 'assembly' produced trim analysis warnings in the context of the app. This means the assembly has not been fully annotated for trimming. Consider contacting the library author to request they add trim annotations to the library. To see detailed warnings for this assembly, turn off grouped warnings by passing either `--singlewarn-` to show detailed warnings for all assemblies, or `--singlewarn- "assembly"` to show detailed warnings for that assembly. https://aka.ms/dotnet-illink/libraries has more information on annotating libraries for trimming.
 
 #### `IL2105`: Type 'type' was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified.
 
-Type name strings representing dynamically accessed types must be assembly qualified, otherwise linker will first search for the type name in the caller's assembly and then in System.Private.CoreLib.
-If the linker fails to resolve the type name, null will be returned.
+- Type name strings representing dynamically accessed types must be assembly qualified, otherwise linker will first search for the type name in the caller's assembly and then in System.Private.CoreLib.
+  If the linker fails to resolve the type name, null will be returned.
 
-```C#
-void TestInvalidTypeName()
-{
-    RequirePublicMethodOnAType("Foo.Unqualified.TypeName");
-}
-void RequirePublicMethodOnAType(
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
-    string typeName)
-{
-}
-```
+  ```C#
+  void TestInvalidTypeName()
+  {
+      RequirePublicMethodOnAType("Foo.Unqualified.TypeName");
+  }
+  void RequirePublicMethodOnAType(
+      [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+      string typeName)
+  {
+  }
+  ```
 
 #### `IL2106`: Trim analysis: Return type of method 'method' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'
 
@@ -1604,6 +1604,39 @@ void RequirePublicMethodOnAType(
   }
   ```
 
+#### `IL2107`: Trim analysis: Methods 'method1' and 'method2' are both associated with state machine type 'type'. This is currently unsupported and may lead to incorrectly reported warnings.
+
+- Trimmer currently can't correctly handle if the same compiler generated state machine type is associated (via the state machine attributes) with two different methods.
+  Since the trimmer currently derives warning suppressions from the method which produced the state machine and currently doesn't support reprocessing the same method/type more than once.
+
+  Only a meta-sample:
+
+  ```C#
+  class <compiler_generated_state_machine>_type {
+      void MoveNext ()
+      {
+          // This should normally produce IL2026
+          CallSomethingWhichRequiresUnreferencedCode ();
+      }
+  }
+
+  [RequiresUnreferencedCode ("")] // This should suppress all warnings from the method
+  [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
+  IEnumerable<int> UserDefinedMethod ()
+  {
+      // Uses the state machine type
+      // The IL2026 from the state machine should be suppressed in this case
+  }
+
+  // IL2107: Methods 'UserDefinedMethod' and 'SecondUserDefinedMethod' are both associated with state machine type '<compiler_generated_state_machine>_type'.
+  [IteratorStateMachine(typeof(<compiler_generated_state_machine>_type))]
+  IEnumerable<int> SecondUserDefinedMethod ()
+  {
+      // Uses the state machine type
+      // The IL2026 from the state should be reported in this case
+  }
+
+  ```
 
 ## Single-File Warning Codes
 

--- a/src/linker/Linker.Steps/MarkScopeStack.cs
+++ b/src/linker/Linker.Steps/MarkScopeStack.cs
@@ -36,12 +36,11 @@ namespace Mono.Linker.Steps
 
 				// Compiler generated methods and types should "inherit" suppression context
 				// from the user defined method from which the compiler generated them.
-				// This is transfered through the SuppressionContextMember as that should
-				// always point to user defined code (and not compiler generated code).
-				// So if the newly added scope is for compiler generated code
-				// keep the suppression context from the current top of the scope stack.
-				// Otherwise the scope is from user code and so its suppression context
-				// should be the same as the scope itself.
+				// Detecting which method produced which piece of compiler generated code
+				// is currently not possible in all cases, but in cases where it works
+				// we will store the suppression context in the SuppressionContextMember.
+				// For code which is not compiler generated the suppression context
+				// is the same as the message's origin member.
 				IMemberDefinition suppressionContextMember = _scopeStack.GetSuppressionContext (origin.MemberDefinition);
 				_scopeStack.Push (new Scope (new MessageOrigin (origin.MemberDefinition, origin.ILOffset, suppressionContextMember)));
 			}

--- a/src/linker/Linker.Steps/MarkScopeStack.cs
+++ b/src/linker/Linker.Steps/MarkScopeStack.cs
@@ -42,12 +42,7 @@ namespace Mono.Linker.Steps
 				// keep the suppression context from the current top of the scope stack.
 				// Otherwise the scope is from user code and so its suppression context
 				// should be the same as the scope itself.
-				IMemberDefinition suppressionContextMember = origin.MemberDefinition;
-				if (origin.MemberDefinition is MemberReference memberRef &&
-					_scopeStack._context.CompilerGeneratedState.IsCompilerGenerated (memberRef)) {
-					suppressionContextMember = _scopeStack.CurrentScope.Origin.SuppressionContextMember;
-				}
-
+				IMemberDefinition suppressionContextMember = _scopeStack.GetSuppressionContext (origin.MemberDefinition);
 				_scopeStack.Push (new Scope (new MessageOrigin (origin.MemberDefinition, origin.ILOffset, suppressionContextMember)));
 			}
 
@@ -143,5 +138,8 @@ namespace Mono.Linker.Steps
 
 		[Conditional ("DEBUG")]
 		public void AssertIsEmpty () => Debug.Assert (_scopeStack.Count == 0);
+
+		IMemberDefinition GetSuppressionContext (IMemberDefinition sourceMember) =>
+			_context.CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember (sourceMember) ?? sourceMember;
 	}
 }

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -10,6 +10,7 @@ namespace Mono.Linker
 	// Currently this is implemented using heuristics
 	public class CompilerGeneratedState
 	{
+		readonly LinkContext _context;
 		readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
 		readonly HashSet<TypeDefinition> _typesWithPopulatedCache;
 
@@ -43,7 +44,12 @@ namespace Mono.Linker
 						TypeDefinition stateMachineType = GetFirstConstructorArgumentAsType (attribute);
 						if (stateMachineType != null) {
 							if (!_compilerGeneratedTypeToUserCodeMethod.TryAdd (stateMachineType, method)) {
-								// TODO: Warn here since we have to "user methods" for one state machine
+								var alreadyAssociatedMethod = _compilerGeneratedTypeToUserCodeMethod[stateMachineType];
+								_context.LogWarning (
+									$"Methods '{method.GetDisplayName ()}' and '{alreadyAssociatedMethod.GetDisplayName ()}' are both associated with state machine type '{stateMachineType.GetDisplayName ()}'. This is currently unsupported and may lead to incorrectly reported warnings.",
+									2107,
+									new MessageOrigin (method),
+									MessageSubCategory.TrimAnalysis);
 							}
 						}
 

--- a/src/linker/Linker/CompilerGeneratedState.cs
+++ b/src/linker/Linker/CompilerGeneratedState.cs
@@ -10,57 +10,78 @@ namespace Mono.Linker
 	// Currently this is implemented using heuristics
 	public class CompilerGeneratedState
 	{
-		enum Language
+		readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
+		readonly HashSet<TypeDefinition> _typesWithPopulatedCache;
+
+		public CompilerGeneratedState ()
 		{
-			CSharp = 0,
-			FSharp = 1
+			_compilerGeneratedTypeToUserCodeMethod = new Dictionary<TypeDefinition, MethodDefinition> ();
+			_typesWithPopulatedCache = new HashSet<TypeDefinition> ();
 		}
 
-		readonly LinkContext _context;
-		readonly Dictionary<AssemblyDefinition, Language> _assumedAssemblyLanguage;
+		static bool HasRoslynCompilerGeneratedName (IMemberDefinition member) =>
+			member.Name.Contains ('<') || member.DeclaringType == null || HasRoslynCompilerGeneratedName (member.DeclaringType);
 
-		public CompilerGeneratedState (LinkContext context)
+		void PopulateCacheForType (TypeDefinition type)
 		{
-			_context = context;
-			_assumedAssemblyLanguage = new Dictionary<AssemblyDefinition, Language> ();
-		}
+			// Avoid repeat scans of the same type
+			if (!_typesWithPopulatedCache.Add (type))
+				return;
 
-		public bool IsCompilerGenerated (MemberReference memberReference)
-		{
-			switch (GetAssumedLanguage (memberReference)) {
-			case Language.CSharp:
-				if (memberReference.Name.Contains ('<'))
-					return true;
-				break;
+			foreach (MethodDefinition method in type.Methods) {
+				if (!method.HasCustomAttributes)
+					continue;
 
-			case Language.FSharp:
-				if (memberReference.Name.Contains ('@'))
-					return true;
-				break;
-			}
+				foreach (var attribute in method.CustomAttributes) {
+					if (attribute.AttributeType.Namespace != "System.Runtime.CompilerServices")
+						continue;
 
-			if (memberReference.DeclaringType != null)
-				return IsCompilerGenerated (memberReference.DeclaringType);
+					switch (attribute.AttributeType.Name) {
+					case "AsyncIteratorStateMachineAttribute":
+					case "AsyncStateMachineAttribute":
+					case "IteratorStateMachineAttribute":
+						TypeDefinition stateMachineType = GetFirstConstructorArgumentAsType (attribute);
+						if (stateMachineType != null) {
+							if (!_compilerGeneratedTypeToUserCodeMethod.TryAdd (stateMachineType, method)) {
+								// TODO: Warn here since we have to "user methods" for one state machine
+							}
+						}
 
-			return false;
-		}
-
-		Language GetAssumedLanguage (MemberReference memberReference)
-		{
-			AssemblyDefinition asm = memberReference.Module.Assembly;
-			if (_assumedAssemblyLanguage.TryGetValue (asm, out Language language))
-				return language;
-
-			language = Language.CSharp;
-			foreach (var attribute in _context.CustomAttributes.GetCustomAttributes (asm)) {
-				if (attribute.AttributeType.IsTypeOf ("Microsoft.FSharp.Core", "FSharpInterfaceDataVersionAttribute")) {
-					language = Language.FSharp;
-					break;
+						break;
+					}
 				}
 			}
+		}
 
-			_assumedAssemblyLanguage.Add (asm, language);
-			return language;
+		static TypeDefinition GetFirstConstructorArgumentAsType (CustomAttribute attribute)
+		{
+			if (!attribute.HasConstructorArguments)
+				return null;
+
+			return attribute.ConstructorArguments[0].Value as TypeDefinition;
+		}
+
+		public MethodDefinition GetUserDefinedMethodForCompilerGeneratedMember (IMemberDefinition sourceMember)
+		{
+			if (sourceMember == null)
+				return null;
+
+			TypeDefinition compilerGeneratedType = (sourceMember as TypeDefinition) ?? sourceMember.DeclaringType;
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out MethodDefinition userDefinedMethod))
+				return userDefinedMethod;
+
+			// Only handle async or iterator state machine
+			// So go to the declaring type and check if it's compiler generated (as a perf optimization)
+			if (!HasRoslynCompilerGeneratedName (compilerGeneratedType) || compilerGeneratedType.DeclaringType == null)
+				return null;
+
+			// Now go to its declaring type and search all methods to find the one which points to the type as its
+			// state machine implementation.
+			PopulateCacheForType (compilerGeneratedType.DeclaringType);
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out userDefinedMethod))
+				return userDefinedMethod;
+
+			return null;
 		}
 	}
 }

--- a/src/linker/Linker/LinkContext.cs
+++ b/src/linker/Linker/LinkContext.cs
@@ -208,7 +208,7 @@ namespace Mono.Linker
 			_actions = new Dictionary<string, AssemblyAction> ();
 			_parameters = new Dictionary<string, string> (StringComparer.Ordinal);
 			_customAttributes = new CustomAttributeSource (this);
-			_compilerGeneratedState = new CompilerGeneratedState (this);
+			_compilerGeneratedState = new CompilerGeneratedState ();
 			_cachedWarningMessageContainers = new List<MessageContainer> ();
 			FeatureSettings = new Dictionary<string, bool> (StringComparer.Ordinal);
 

--- a/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
+++ b/test/Mono.Linker.Tests.Cases/Warnings/WarningSuppression/SuppressWarningsInCompilerGeneratedCode.cs
@@ -157,11 +157,14 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLocalFunction
 		{
+			// Suppression currently doesn't propagate to local functions
+
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -170,6 +173,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => typeof (SuppressWarningsInCompilerGeneratedCode)
 					.GetMethod ("RequiresUnreferencedCodeMethod", System.Reflection.BindingFlags.NonPublic)
 					.Invoke (null, new object[] { });
@@ -180,7 +184,9 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
-				void LocalFunction () { var _ = new Action (RequiresUnreferencedCodeMethod); }
+				[ExpectedWarning ("IL2026")]
+				void LocalFunction ()
+				{ var _ = new Action (RequiresUnreferencedCodeMethod); }
 			}
 
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
@@ -188,6 +194,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
@@ -196,6 +203,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2077")]
 				void LocalFunction () => unknownType.RequiresNonPublicMethods ();
 			}
 
@@ -204,6 +212,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2091")]
 				void LocalFunction () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
@@ -212,6 +221,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2091")]
 				void LocalFunction () => new TypeWithGenericWhichRequiresNonPublicFields<TUnknown> ();
 			}
 
@@ -231,10 +241,34 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction<TUnknown> ();
 
+				[ExpectedWarning ("IL2087")]
 				void LocalFunction<TSecond> ()
 				{
 					typeof (TUnknown).RequiresPublicMethods ();
 					typeof (TSecond).RequiresPublicMethods ();
+				}
+			}
+
+			static void TestGenericLocalFunctionWithAnnotations<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> ()
+			{
+				LocalFunction<TPublicMethods> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TInnerPublicMethods> ()
+				{
+					typeof (TPublicMethods).RequiresPublicMethods ();
+					typeof (TInnerPublicMethods).RequiresPublicMethods ();
+				}
+			}
+
+			static void TestGenericLocalFunctionWithAnnotationsAndClosure<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TPublicMethods> (int p = 0)
+			{
+				LocalFunction<TPublicMethods> ();
+
+				void LocalFunction<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] TInnerPublicMethods> ()
+				{
+					p++;
+					typeof (TPublicMethods).RequiresPublicMethods ();
+					typeof (TInnerPublicMethods).RequiresPublicMethods ();
 				}
 			}
 
@@ -243,6 +277,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				var _ = new Action (LocalFunction);
 
+				[ExpectedWarning ("IL2026")]
 				void LocalFunction () => RequiresUnreferencedCodeMethod ();
 			}
 
@@ -253,6 +288,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				{
 					typeof (DynamicallyAccessedLocalFunction).RequiresNonPublicMethods ();
 
+					[ExpectedWarning ("IL2026")]
 					void LocalFunction () => RequiresUnreferencedCodeMethod ();
 				}
 			}
@@ -273,6 +309,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			{
 				LocalFunction ();
 
+				[ExpectedWarning ("IL2067")]
 				[UnconditionalSuppressMessage ("Test", "IL2026")] // This supresses the RequiresUnreferencedCodeMethod
 				void LocalFunction (Type unknownType = null)
 				{
@@ -301,12 +338,16 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 
 		class SuppressInLambda
 		{
+			// Suppression currently doesn't propagate to local functions
+
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestCallRUCMethod ()
 			{
 				Action _ = () => RequiresUnreferencedCodeMethod ();
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestReflectionAccessRUCMethod ()
 			{
@@ -315,30 +356,35 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 					.Invoke (null, new object[] { });
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestLdftnOnRUCMethod ()
 			{
 				Action _ = () => { var _ = new Action (RequiresUnreferencedCodeMethod); };
 			}
 
+			[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2026")]
 			static void TestDynamicallyAccessedMethod ()
 			{
 				Action _ = () => typeof (TypeWithRUCMethod).RequiresNonPublicMethods ();
 			}
 
+			[ExpectedWarning ("IL2077", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2077")]
 			static void TestMethodParameterWithRequirements (Type unknownType = null)
 			{
 				Action _ = () => unknownType.RequiresNonPublicMethods ();
 			}
 
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericMethodParameterRequirement<TUnknown> ()
 			{
 				Action _ = () => MethodWithGenericWhichRequiresMethods<TUnknown> ();
 			}
 
+			[ExpectedWarning ("IL2091", CompilerGeneratedCode = true)]
 			[UnconditionalSuppressMessage ("Test", "IL2091")]
 			static void TestGenericTypeParameterRequirement<TUnknown> ()
 			{
@@ -366,6 +412,23 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 				LocalFunction ();
 				await MethodAsync ();
 
+				[UnconditionalSuppressMessage ("Test", "IL2026")]
+				IEnumerable<int> LocalFunction ()
+				{
+					yield return 0;
+					RequiresUnreferencedCodeMethod ();
+					yield return 1;
+				}
+			}
+
+			[UnconditionalSuppressMessage ("Test", "IL2026")]
+			static async void TestIteratorLocalFunctionInAsyncWithoutInner ()
+			{
+				await MethodAsync ();
+				LocalFunction ();
+				await MethodAsync ();
+
+				[ExpectedWarning ("IL2026", CompilerGeneratedCode = true)]
 				IEnumerable<int> LocalFunction ()
 				{
 					yield return 0;
@@ -384,6 +447,7 @@ namespace Mono.Linker.Tests.Cases.Warnings.WarningSuppression
 			public static void Test ()
 			{
 				TestIteratorLocalFunctionInAsync ();
+				TestIteratorLocalFunctionInAsyncWithoutInner ();
 				TestDynamicallyAccessedMethodViaGenericMethodParameterInIterator ();
 			}
 		}


### PR DESCRIPTION
Changes the implementation to not use marking stack to deduce suppression context. Instead it relies on state machine attributes (`IteratorStateMachine`, `AsyncStateMachine`, ...) - these are generated by the compiler onto the original user method and point to the state machine type (compiler generated) which implements the body of the method.

This makes the behavior much more robust and predictable. The downside is that suppressions only propagate to iterator and async method bodies, they don't propagate to local functions and lambdas.

The information about the mapping between methods and state machine types is cached to avoid rescans which are relatively expensive.

Adapted the tests to the new behavior.